### PR TITLE
Relax constraint on base dependancy to support GHC 7.4

### DIFF
--- a/monad-control.cabal
+++ b/monad-control.cabal
@@ -45,7 +45,7 @@ source-repository head
 Library
   Exposed-modules: Control.Monad.Trans.Control
 
-  Build-depends: base                 >= 3     && < 4.5
+  Build-depends: base                 >= 3     && < 4.6
                , base-unicode-symbols >= 0.1.1 && < 0.3
                , transformers         >= 0.2   && < 0.3
                , transformers-base    >= 0.4   && < 0.5


### PR DESCRIPTION
GHC 7.4 will ship with base-4.5.0.0
