### PR TITLE
Fix preprocessor directive for GHC 7.6.3

### DIFF
--- a/Control/Monad/Trans/Control.hs
+++ b/Control/Monad/Trans/Control.hs
@@ -6,8 +6,7 @@
            , FunctionalDependencies
            , FlexibleInstances
            , UndecidableInstances
-           , MultiParamTypeClasses
-  #-}
+           , MultiParamTypeClasses #-}
 
 #if __GLASGOW_HASKELL__ >= 702
 {-# LANGUAGE Trustworthy #-}


### PR DESCRIPTION
Fails to compile and install on GHC 7.6.3 (bottled from homebrew, on osx 10.8.5)

Complains about wrong preprocessor directive

```
Control/Monad/Trans/Control.hs:10:4:
     error: invalid preprocessing directive
      #-}
       ^
```
