### PR TITLE
Use Safe instead of Trustworthy

### DIFF
--- a/Control/Monad/Trans/Control.hs
+++ b/Control/Monad/Trans/Control.hs
@@ -8,7 +8,7 @@
            , MultiParamTypeClasses #-}
 
 #if __GLASGOW_HASKELL__ >= 702
-{-# LANGUAGE Trustworthy #-}
+{-# LANGUAGE Safe #-}
 #endif
 
 #if MIN_VERSION_transformers(0,4,0)
@@ -61,13 +61,11 @@ import System.IO     ( IO )
 import Data.Maybe    ( Maybe )
 import Data.Either   ( Either )
 
-#if MIN_VERSION_base(4,3,0)
-import GHC.Conc.Sync ( STM )
-#endif
+import Control.Monad.STM ( STM )
 
 #if MIN_VERSION_base(4,4,0)
-import           Control.Monad.ST.Lazy             ( ST )
-import qualified Control.Monad.ST.Strict as Strict ( ST )
+import           Control.Monad.ST.Lazy.Safe           ( ST )
+import qualified Control.Monad.ST.Safe      as Strict ( ST )
 #endif
 
 -- from transformers:
@@ -348,9 +346,7 @@ BASE([])
 BASE((->) r)
 BASE(Identity)
 
-#if MIN_VERSION_base(4,3,0)
 BASE(STM)
-#endif
 
 #if MIN_VERSION_base(4,4,0)
 BASE(Strict.ST s)

--- a/monad-control.cabal
+++ b/monad-control.cabal
@@ -41,7 +41,8 @@ Library
   Exposed-modules: Control.Monad.Trans.Control
 
   Build-depends: base                 >= 3     && < 5
+               , stm                  >= 2.3
+               , transformers-base    >= 0.4.3 && < 0.5
                , transformers         >= 0.2   && < 0.5
-               , transformers-base    >= 0.4.2 && < 0.5
 
   Ghc-options: -Wall


### PR DESCRIPTION
As of version 0.4.3, [`transformer-base`](http://hackage.haskell.org/package/transformers-base) uses the Safe Haskell extension, so it's possible to switch from Trustworthy to Safe in `monad-control`. This requires adding an additional dependency on the [`stm`](http://hackage.haskell.org/package/stm) package, which is already required by `transformer-base` 0.4.3.
