### PR TITLE
Unconditionally add ExceptT instances using transformers-compat

### DIFF
--- a/Control/Monad/Trans/Control.hs
+++ b/Control/Monad/Trans/Control.hs
@@ -80,10 +80,7 @@ import Control.Monad.Trans.Reader   ( ReaderT  (ReaderT),   runReaderT )
 import Control.Monad.Trans.State    ( StateT   (StateT),    runStateT )
 import Control.Monad.Trans.Writer   ( WriterT  (WriterT),   runWriterT )
 import Control.Monad.Trans.RWS      ( RWST     (RWST),      runRWST )
-
-#if MIN_VERSION_transformers(0,4,0)
 import Control.Monad.Trans.Except   ( ExceptT  (ExceptT),   runExceptT )
-#endif
 
 import qualified Control.Monad.Trans.RWS.Strict    as Strict ( RWST   (RWST),    runRWST )
 import qualified Control.Monad.Trans.State.Strict  as Strict ( StateT (StateT),  runStateT )
@@ -213,14 +210,12 @@ instance Error e => MonadTransControl (ErrorT e) where
     {-# INLINABLE liftWith #-}
     {-# INLINABLE restoreT #-}
 
-#if MIN_VERSION_transformers(0,4,0)
 instance MonadTransControl (ExceptT e) where
     type StT (ExceptT e) a = Either e a
     liftWith f = ExceptT $ liftM return $ f $ runExceptT
     restoreT = ExceptT
     {-# INLINABLE liftWith #-}
     {-# INLINABLE restoreT #-}
-#endif
 
 instance MonadTransControl ListT where
     type StT ListT a = [a]
@@ -439,10 +434,7 @@ TRANS(ListT)
 TRANS(ReaderT r)
 TRANS(Strict.StateT s)
 TRANS(       StateT s)
-
-#if MIN_VERSION_transformers(0,4,0)
 TRANS(ExceptT e)
-#endif
 
 TRANS_CTX(Error e,         ErrorT e)
 TRANS_CTX(Monoid w, Strict.WriterT w)

--- a/monad-control.cabal
+++ b/monad-control.cabal
@@ -42,7 +42,8 @@ Library
 
   Build-depends: base                 >= 4.5   && < 5
                , stm                  >= 2.3   && < 3
-               , transformers-base    >= 0.4.3 && < 0.5
+               , transformers-base    >= 0.4.4 && < 0.5
                , transformers         >= 0.2   && < 0.5
+               , transformers-compat  == 0.3.*
 
   Ghc-options: -Wall


### PR DESCRIPTION
This is needed to allow reverse-dependencies to migrate to `ExceptT` using `transformers-compat` while keeping backwards compatibility for older versions of `transformers`.

Note that this depends on https://github.com/mvv/transformers-base/pull/7 , I'll notify you here once that has been resolved.
