### PR TITLE
Add instances for `AccumT`

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+1.0.4.0
+
+* Add instances for `AccumT`
+
 1.0.3.1.
 
 * Support transformers-0.6

--- a/monad-control.cabal
+++ b/monad-control.cabal
@@ -1,5 +1,5 @@
 name:               monad-control
-version:            1.0.3.1
+version:            1.0.4.0
 synopsis:
   Lift control operations, like exception catching, through monad transformers
 
@@ -67,4 +67,4 @@ library
     , stm                  >=2.3   && <3
     , transformers         >=0.2   && <0.7
     , transformers-base    >=0.4.4 && <0.5
-    , transformers-compat  >=0.3   && <0.8
+    , transformers-compat  >=0.5.3 && <0.8

--- a/src/Control/Monad/Trans/Control.hs
+++ b/src/Control/Monad/Trans/Control.hs
@@ -121,6 +121,7 @@ import Control.Monad.Trans.State    ( StateT   (StateT),    runStateT )
 import Control.Monad.Trans.Writer   ( WriterT  (WriterT),   runWriterT )
 import Control.Monad.Trans.RWS      ( RWST     (RWST),      runRWST )
 import Control.Monad.Trans.Except   ( ExceptT  (ExceptT),   runExceptT )
+import Control.Monad.Trans.Accum    ( AccumT   (AccumT),    runAccumT )
 
 #if !(MIN_VERSION_transformers(0,6,0))
 import Control.Monad.Trans.List     ( ListT    (ListT),     runListT )
@@ -499,6 +500,15 @@ instance Monoid w => MonadTransControl (Strict.RWST r w s) where
     {-# INLINABLE liftWith #-}
     {-# INLINABLE restoreT #-}
 
+instance Monoid w => MonadTransControl (AccumT w) where
+    type StT (AccumT w) a = (a, w)
+    liftWith f = AccumT $ \s ->
+                   liftM (\x -> (x, s))
+                         (f $ \t -> runAccumT t s)
+    restoreT = AccumT . const
+    {-# INLINABLE liftWith #-}
+    {-# INLINABLE restoreT #-}
+
 
 --------------------------------------------------------------------------------
 -- MonadBaseControl type class
@@ -725,6 +735,7 @@ TRANS_CTX(Monoid w, Strict.WriterT w)
 TRANS_CTX(Monoid w,        WriterT w)
 TRANS_CTX(Monoid w, Strict.RWST r w s)
 TRANS_CTX(Monoid w,        RWST r w s)
+TRANS_CTX(Monoid w,        AccumT w)
 
 #if !(MIN_VERSION_transformers(0,6,0))
 TRANS(ListT)


### PR DESCRIPTION
The AccumT monad transformer has been available since transformers-0.5.3.0. It is very similar in structure to StateT, so much of the code was copied directly from the StateT instances.

Bumps the version to 1.0.4.0